### PR TITLE
include AWS.Credentials:sessionToken support

### DIFF
--- a/connection.schema.json
+++ b/connection.schema.json
@@ -17,6 +17,10 @@
       "type": "string",
       "minLength": 1
     },
+    "sessionToken": {
+      "title": "Session Token (optional)",
+      "type": "string"
+    },
     "filter": {
       "title": "Table pattern",
       "type": "string",

--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -14,15 +14,15 @@ export default class DynamoDbDriver
     if (this.connection) {
       return this.connection;
     }
-    
     const clientConfig: DynamoDBConfig = {
       region: this.credentials.region,
       credentials: {
         accessKeyId: this.credentials.accessKeyId,
         secretAccessKey: this.credentials.secretAccessKey,
+        sessionToken: this.credentials.sessionToken
       },
     };
-
+    
     const client = new DynamoDBLib(clientConfig);
     this.connection = Promise.resolve(client);
     return  this.connection;

--- a/ui.schema.json
+++ b/ui.schema.json
@@ -1,3 +1,3 @@
 {
-  "ui:order": ["region", "accessKeyId", "secretAccessKey"]
+  "ui:order": ["region", "accessKeyId", "secretAccessKey", "sessionToken"]
 }


### PR DESCRIPTION
Added support for included a sessionToken which is required for some SSO style credentials. Would love to be able to just use ~/.aws/credentials file but this works for now.  @khanghua-itr can you test it still works without the sessionToken entry?